### PR TITLE
adding a cleaning command for the extra directory

### DIFF
--- a/custom_build.sh
+++ b/custom_build.sh
@@ -94,6 +94,7 @@ function download_plugin()  {
 
 
   download_from_url_to_a_filepath "${PLUGIN_ARTIFACT_URL}" "${PLUGIN_ARTIFACT_DIRECTORY}/${PLUGIN_FULL_NAME}"
+  rm -Rf https:
 }
 
 function download_fonts()  {

--- a/custom_build.sh
+++ b/custom_build.sh
@@ -87,9 +87,9 @@ function download_plugin()  {
 	esac
 
 
-  if [ ! -e "${PLUGIN_ARTIFACT_URL}" ]; then
-      mkdir -p "${PLUGIN_ARTIFACT_URL}"
-  fi
+#  if [ ! -e "${PLUGIN_ARTIFACT_URL}" ]; then
+#      mkdir -p "${PLUGIN_ARTIFACT_URL}"
+#  fi
 
 
 


### PR DESCRIPTION
after an investigation of the issue, I found out that the directory is created by this command:
```bash
if [ ! -e "${PLUGIN_ARTIFACT_URL}" ]; then
      mkdir -p "${PLUGIN_ARTIFACT_URL}"
  fi
``` 
the `rm -Rf http:` at the end of the function will resolve geosolutions-it/docker-geoserver#45 