### PR TITLE
adding the docker 18 version to the conditional

### DIFF
--- a/custom_build.sh
+++ b/custom_build.sh
@@ -160,6 +160,14 @@ function build_with_data_dir() {
         DOCKER_BUILD_COMMAND="docker build --no-cache"
       fi;
       ;;
+    *"18"*)
+      if [[ "${PULL_ENABLED}" == "pull" ]]; then        
+        DOCKER_BUILD_COMMAND="docker build --pull --no-cache"    
+      else
+        DOCKER_BUILD_COMMAND="docker build --no-cache"
+      fi;
+      ;;
+ 
   esac
 	${DOCKER_BUILD_COMMAND} --build-arg GEOSERVER_WEBAPP_SRC=${GEOSERVER_ARTIFACT_DIRECTORY}/geoserver.war \
     --build-arg PLUG_IN_URLS=$PLUGIN_ARTIFACT_DIRECTORY \
@@ -190,6 +198,14 @@ function build_without_data_dir() {
         DOCKER_BUILD_COMMAND="docker build --no-cache"
       fi;
       ;;
+    *"18"*)
+      if [[ "${PULL_ENABLED}" == "pull" ]]; then        
+        DOCKER_BUILD_COMMAND="docker build --pull --no-cache"    
+      else
+        DOCKER_BUILD_COMMAND="docker build --no-cache"
+      fi;
+      ;;
+ 
   esac
 	${DOCKER_BUILD_COMMAND} --build-arg GEOSERVER_WEBAPP_SRC=${GEOSERVER_ARTIFACT_DIRECTORY}/geoserver.war \
     --build-arg PLUG_IN_URLS=$PLUGIN_ARTIFACT_DIRECTORY \


### PR DESCRIPTION
- Adding the conditional for version 18, so when you build with docker 18.x don't get errors.
- this issue that might be helpful for another projects. ex. https://github.com/geosolutions-it/internal/issues/119