### PR TITLE
fixed hooks/test

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
   sut:
-    image: ${DOCKER_REPO}:test-$VERSION
+    image: ${DOCKER_REPO}:$VERSION
     command: /docker/tests/run_tests.sh
     environment:
      - SOURCE_BRANCH


### PR DESCRIPTION
docker hub builds are broken if tests do not run correctly, I think that this is a regression due to some commits not ported back from `docker-hub-build` branch, present PR fixes it.
@randomorder would you mind to merge so I can test it tomorrow?