### PR TITLE
Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ADD "${GEOSERVER_WEBAPP_SRC}" "./"
 RUN wget https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.0.6.tar.gz \
     && tar -zxf ./2.0.6.tar.gz \
     && cd libjpeg-turbo-2.0.6 && apt-get install cmake -yq && cmake -G"Unix Makefiles" && make deb \
-    && dpkg -i ./libjpeg*.deb && apt-get -f install \
+    && dpkg -i ./libjpeg*.deb && apt-get -f install -y \
     && apt-get clean \
     && apt-get autoclean \
     && apt-get autoremove

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ ARG GEOSERVER_WEBAPP_SRC="./.placeholder"
 ADD "${GEOSERVER_WEBAPP_SRC}" "./"
 
 # download and install libjpeg-2.0.6 from sources.
-RUN wget https://nav.dl.sourceforge.net/project/libjpeg-turbo/2.0.6/libjpeg-turbo-2.0.6.tar.gz \
-    && tar -zxf ./libjpeg-turbo-2.0.6.tar.gz \
+RUN wget https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.0.6.tar.gz \
+    && tar -zxf ./2.0.6.tar.gz \
     && cd libjpeg-turbo-2.0.6 && apt-get install cmake -yq && cmake -G"Unix Makefiles" && make deb \
     && dpkg -i ./libjpeg*.deb && apt-get -f install \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services:
 
 If you want to build the image by yourself just run `docker build` from the root of the repository
 
-` docker build -t geoserver:test . --build-args GEOSERVER_WEBAPP_SRC="./geoserver.war"`
+` docker build --build-args GEOSERVER_WEBAPP_SRC="./geoserver.war" -t geoserver:test .`
 
 There are [**build arguments**](https://docs.docker.com/engine/reference/commandline/build/) to customize the image:
 - `GEOSERVER_DATA_DIR_SRC` to add your own custom datadir to the final image. This can be a local zip or directory or remote URL (see [ADD](https://docs.docker.com/engine/reference/builder/#add) instruction Doc)


### PR DESCRIPTION
- Replacing SourceForge by GitHub to speed up `docker build` when downloading the archive
- Fix readme to have the correct build syntax because existing returns: "unknown flag: --build-args"
- Add missing "-y" flag for `apt-get -f install` to silently accept the installation of possible dependencies needed by libjpeg-turbo