### PR TITLE
Update test_hooks.sh

### DIFF
--- a/test_hooks.sh
+++ b/test_hooks.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/bash -x
-export MAINT_VERSION="2.18.3 2.18.2 2.18.1 2.18.0"
+export MAINT_VERSION="2.18.4 2.18.3 2.18.2 2.18.1 2.18.0"
 export MIDDLE_STABLE="19"
 export NIGHTLY_MAINT_VERSION="2.18.x"
 export NIGHTLY_MASTER_VERSION="main foobar"
 export NIGHTLY_STABLE_VERSION="2.19.x"
-export STABLE_VERSION="2.19.0"
+export STABLE_VERSION="2.19.2"
 export DOCKERFILE_PATH="./Dockerfile"
 export DOCKER_REPO="somethingnotreal"
 source hooks/build


### PR DESCRIPTION
Update GeoServer list of version numbers to build. This is to update the list of stable and maint versions
We'll need a separate PR to _latest_ tagged docker image