### PR TITLE
Changing absolute bash path in /usr/bin/env

### DIFF
--- a/test_hooks.sh
+++ b/test_hooks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -x
+#!/usr/bin/env bash
 export MAINT_VERSION="2.18.4 2.18.3 2.18.2 2.18.1 2.18.0"
 export MIDDLE_STABLE="19"
 export NIGHTLY_MAINT_VERSION="2.18.x"


### PR DESCRIPTION
Replacing /usr/bin/bash with /usr/bin/env bash

Not always /usr/bin/bash is a valid bash path.