### PR TITLE
Fix geoserver-rest-reload.sh

### DIFF
--- a/geoserver-rest-reload.sh
+++ b/geoserver-rest-reload.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/bash -x
+#!/usr/bin/env bash
+set -x
 #while [ "$(curl -s --retry-connrefused --retry 100 -I http://localhost:8080/geoserver/web/ 2>&1 |grep 200)" == "" ];do
 #  echo "Waiting for GeoServer to be Up and running"
 #done  


### PR DESCRIPTION
@randomorder 
Fix bash path, because there is no soft/hard link in `/usr/bin/` inside base image `tomcat:9-jdk11-openjdk`.
Use `/usr/bin/env bash` instead.