### PR TITLE
Leo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,10 @@ ENV JAVA_OPTS="-Xms${INITIAL_MEMORY} -Xmx${MAXIMUM_MEMORY} \
   -XX:MaxGCPauseMillis=200 -XX:ParallelGCThreads=20 -XX:ConcGCThreads=5 \
   ${GEOSERVER_OPTS}"
 
+# added for git hash
+ARG GIT_HASH=""
+ENV GIT_HASH "$GIT_HASH"
+
 COPY run_tests.sh /docker/tests/run_tests.sh
 
 # install needed packages and create externalized dirs

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example of how to build a docker image with just geoserver war and then add plug
 
 ```bash
 docker build -t geoserver:test-2.19.1 \
---build-arg GIT_HASH=`git show -s --format=%h`
+--build-arg GIT_HASH=`git show -s --format=%H`
 --build-arg GEOSERVER_WEBAPP_SRC=https://sourceforge.net/projects/geoserver/files/GeoServer/2.19.1/geoserver-2.19.1-war.zip/download  .
 
 docker run \
@@ -423,6 +423,10 @@ This script is meant to be used by automated build, variety of tests with highly
 
 ### GIT HASH INFORMATION
 
-Added git hash information inside of container so for the source code information below command can check the env variable GIT_HASH
+This argument provides git hash information from inside of container. In order to get git hash information inside of container add this argument to the build line. As requirement git command should be installed.
+
+--build-arg GIT_HASH=`git show -s --format=%H`
+
+Below command shows git hash information.
 
 docker exec -it <geoserver-container-name>  bash -c 'echo $GIT_HASH'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Example of how to build a docker image with just geoserver war and then add plug
 
 ```bash
 docker build -t geoserver:test-2.19.1 \
+--build-arg GIT_HASH=`git show -s --format=%h`
 --build-arg GEOSERVER_WEBAPP_SRC=https://sourceforge.net/projects/geoserver/files/GeoServer/2.19.1/geoserver-2.19.1-war.zip/download  .
 
 docker run \
@@ -419,3 +420,9 @@ This script is meant to be used by automated build, variety of tests with highly
 ```bash
 ./custom_build.sh my-docker-tag 2.18.x 2.18.x nodatadir no_pull
 ```
+
+### GIT HASH INFORMATION
+
+Added git hash information inside of container so for the source code information below command can check the env variable GIT_HASH
+
+docker exec -it <geoserver-container-name>  bash -c 'echo $GIT_HASH'

--- a/custom_build.sh
+++ b/custom_build.sh
@@ -2,6 +2,7 @@
 
 set -e
 TAG=${1}
+GIT_HASH_COMMAND="`git show -s --format=%H`"
 readonly GEOSERVER_VERSION=${2}
 readonly GEOSERVER_MASTER_VERSION=${3}
 readonly GEOSERVER_DATA_DIR_RELEASE=${4}
@@ -173,6 +174,7 @@ function build_with_data_dir() {
     --build-arg PLUG_IN_PATHS=$PLUGIN_ARTIFACT_DIRECTORY \
     --build-arg GEOSERVER_DATA_DIR_SRC=${DATADIR_ARTIFACT_DIRECTORY} \
     --build-arg UID=${USERID} --build-arg GID=${GROUPID} --build-arg UNAME=${UNAME} \
+    --build-arg GIT_HASH=${GIT_HASH_COMMAND} \
 		-t geosolutionsit/geoserver:"${TAG}-${GEOSERVER_VERSION}" \
 		 .
 }
@@ -210,6 +212,7 @@ function build_without_data_dir() {
 	${DOCKER_BUILD_COMMAND} --build-arg GEOSERVER_WEBAPP_SRC=${GEOSERVER_ARTIFACT_DIRECTORY}/geoserver.war \
     --build-arg PLUG_IN_PATHS=$PLUGIN_ARTIFACT_DIRECTORY \
     --build-arg UID=${USERID} --build-arg GID=${GROUPID} --build-arg UNAME=${UNAME} \
+    --build-arg GIT_HASH=${GIT_HASH_COMMAND} \
 		-t geosolutionsit/geoserver:"${TAG}-${GEOSERVER_VERSION}" \
 		 .
 }


### PR DESCRIPTION
Added git hash information as a build argument and env variable inside of docker so it can be displayed inside of geoserver container via GIT_HASH env variable. As a requirement git should be installed.