### PR TITLE
Issue #125 changed proxy_temp_file_write_size conf to 512kb

### DIFF
--- a/geoserver.conf
+++ b/geoserver.conf
@@ -38,7 +38,7 @@ server {
         proxy_buffers 4 512k;
         proxy_busy_buffers_size 512k;
         proxy_max_temp_file_size 2048m;
-        proxy_temp_file_write_size 32k;
+        proxy_temp_file_write_size 512k;
 
         location / {
                 deny all;


### PR DESCRIPTION
Issue #123, this commit fixes the `proxy_temp_file_write_size` configuration item to make it equal or higher to `proxy_buffer_size`.