### PR TITLE
CATALINA_OPTS and EXTRA_GEOSERVER_OPTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ ENV GEOWEBCACHE_CONFIG_DIR="${GEOSERVER_DATA_DIR}/gwc"
 ENV GEOWEBCACHE_CACHE_DIR="${GEOSERVER_HOME}/gwc_cache_dir"
 ENV NETCDF_DATA_DIR="${GEOSERVER_HOME}/netcdf_data_dir"
 ENV GRIB_CACHE_DIR="${GEOSERVER_HOME}/grib_cache_dir"
-# override at run time as needed JAVA_OPTS
+# override at run time as needed CATALINA_OPTS
 ENV INITIAL_MEMORY="2G"
 ENV MAXIMUM_MEMORY="4G"
 ENV LD_LIBRARY_PATH="/opt/libjpeg-turbo/lib64"
@@ -95,7 +95,7 @@ ENV GEOSERVER_OPTS=" \
   -DNETCDF_DATA_DIR=${NETCDF_DATA_DIR} \
   -DGRIB_CACHE_DIR=${GRIB_CACHE_DIR}"
 
-ENV JAVA_OPTS="-Xms${INITIAL_MEMORY} -Xmx${MAXIMUM_MEMORY} \
+ENV CATALINA_OPTS="-Xms${INITIAL_MEMORY} -Xmx${MAXIMUM_MEMORY} \
   -Djava.awt.headless=true -server \
   -Dfile.encoding=UTF8 \
   -Djavax.servlet.request.encoding=UTF-8 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ ENV MAXIMUM_MEMORY="4G"
 ENV LD_LIBRARY_PATH="/opt/libjpeg-turbo/lib64"
 ENV JAIEXT_ENABLED="true"
 ENV PLUGIN_DYNAMIC_URLS=""
+ENV EXTRA_GEOSERVER_OPTS=""
 ENV GEOSERVER_OPTS=" \
   -Dorg.geotools.coverage.jaiext.enabled=${JAIEXT_ENABLED} \
   -Duser.timezone=UTC \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Open your browser and point it to `http://localhost:8080/geoserver` .
 GeoServer web interface will show up, you can now log in with user admin and password `geoserver`.
 
 There are some [**environment variables**](https://docs.docker.com/engine/reference/run/) you can use at run time:
-- `JAVA_OPTS` to customize JAVA_OPTS for the container
+- `CATALINA_OPTS` to customize CATALINA_OPTS for the container
 - `GEOSERVER_LOG_DIR` to customize log placement
 - `GEOSERVER_DATA_DIR` to put your GeoServer datadir elsewhere
 - `GEOWEBCACHE_CONFIG_DIR` to put your GeoServer cache configuration elsewhere

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ GeoServer web interface will show up, you can now log in with user admin and pas
 
 There are some [**environment variables**](https://docs.docker.com/engine/reference/run/) you can use at run time:
 - `CATALINA_OPTS` to customize CATALINA_OPTS for the container
+- `EXTRA_GEOSERVER_OPTS` to append to CATALINA_OPTS
 - `GEOSERVER_LOG_DIR` to customize log placement
 - `GEOSERVER_DATA_DIR` to put your GeoServer datadir elsewhere
 - `GEOWEBCACHE_CONFIG_DIR` to put your GeoServer cache configuration elsewhere

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 geoserver-plugin-download.sh ${CATALINA_BASE}/webapps/${APP_LOCATION}/WEB-INF/lib $PLUGIN_DYNAMIC_URLS
 set -m
+export CATALINA_OPTS="$CATALINA_OPTS $EXTRA_GEOSERVER_OPTS"
 catalina.sh run &
 /usr/local/bin/geoserver-rest-config.sh
 fg %1


### PR DESCRIPTION
This resolves #133.

`CATALINA_OPTS` is now used in place of `JAVA_OPTS`.
`EXTRA_GEOSERVER_OPTS` is now available for the user to append vars to `CATALINA_OPTS`.

Example:
```sh
docker run --rm -it -p8080:8080 -e EXTRA_GEOSERVER_OPTS='-DGEOSERVER_LOG_LOCATION=/log.log'  docker-geoserver:latest
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```