### PR TITLE
Install unzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ COPY run_tests.sh /docker/tests/run_tests.sh
 # install needed packages and create externalized dirs
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install --yes git vim gdal-bin postgresql-client fontconfig libfreetype6 jq \
+    && apt-get install --yes git vim gdal-bin postgresql-client fontconfig libfreetype6 jq unzip \
     && apt-get clean \
     && apt-get -y autoclean \
     && apt-get -y autoremove \


### PR DESCRIPTION
unzip is needed to extract plugins downloaded with PLUGIN_DYNAMIC_URLS.