### PR TITLE
install the necessary fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,6 @@ FROM tomcat:9-jdk11-temurin
 ARG UID=1000
 ARG GID=1000
 ARG UNAME=tomcat
-ARG CUSTOM_FONTS="./.placeholder"
 ENV ADMIN_PASSWORD=""
 ENV APP_LOCATION="geoserver"
 
@@ -141,7 +140,11 @@ COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
 COPY geoserver-rest-config.sh /usr/local/bin/geoserver-rest-config.sh
 COPY geoserver-rest-reload.sh /usr/local/bin/geoserver-rest-reload.sh
 COPY entrypoint.sh /entrypoint.sh
-COPY ${CUSTOM_FONTS} $GEOSERVER_DATA_DIR/styles/
+
+# Install the necessary fonts
+USER root
+RUN apt-get update && apt-get install -y fonts-noto fonts-dejavu unifont fonts-hanazono && fc-cache -f
+
 RUN groupadd -g $GID $UNAME
 RUN useradd -m -u $UID -g $GID --system $UNAME
 RUN chown -R $UID:$GID $GEOSERVER_LOG_DIR $CATALINA_BASE $GEOWEBCACHE_CACHE_DIR $GEOWEBCACHE_CONFIG_DIR $NETCDF_DATA_DIR $GRIB_CACHE_DIR $GEOSERVER_DATA_DIR


### PR DESCRIPTION
Executing the command as root on line 146 installs the fonts correctly, and the ```fc-cache``` command build, update, and clear the font cache files