### PR TITLE
force tomcat image to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-temurin as mother
+FROM tomcat:9-jdk11-temurin-jammy as mother
 LABEL maintainer="Alessandro Parma <alessandro.parma@geosolutionsgroup.com>"
 SHELL ["/bin/bash", "-c"]
 
@@ -59,7 +59,7 @@ RUN \
       mv /output/webapp/geoserver /output/webapp/${APP_LOCATION}; \
     fi
 
-FROM tomcat:9-jdk11-temurin
+FROM tomcat:9-jdk11-temurin-jammy
 
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
Explicitly set Ubuntu version to 22.04 in the parent image to avod breacking changes to the docker images