### PR TITLE
Use platform JDK package to leverage faster native JPEG encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ COPY run_tests.sh /docker/tests/run_tests.sh
 # install needed packages and create externalized dirs
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get install --yes git vim gdal-bin postgresql-client fontconfig libfreetype6 jq unzip \
+    && apt-get install --yes git vim gdal-bin postgresql-client fontconfig libfreetype6 jq unzip openjdk-11-jdk-headless \
     && apt-get clean \
     && apt-get -y autoclean \
     && apt-get -y autoremove \
@@ -126,6 +126,9 @@ RUN apt-get update \
     "${GEOWEBCACHE_CACHE_DIR}" \
     "${NETCDF_DATA_DIR}" \
     "${GRIB_CACHE_DIR}"
+
+# Remove the Tomcat docker installed Java, we're not going to use it
+RUN rm -rf /opt/java
 
 # copy from mother
 COPY --from=mother "/output/datadir" "${GEOSERVER_DATA_DIR}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,10 @@ fi
 # Disable tomcat version disclosure
 sed -i '/<\/Host>/i\ \ \ \ \ \ \ \ <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false"/>' "$CATALINA_HOME/conf/server.xml";
 
+# Enforce usage of distribution own Java
+export PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH"
+export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+
 catalina.sh run &
 /usr/local/bin/geoserver-rest-config.sh
 fg %1


### PR DESCRIPTION
This is a better alternative to the turbo-jpeg plugin, without the need of a native build, and uses significantly less memory (not easily OOM prone).