### PR TITLE
Dockerfile: fix to have many plugins zips

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ ADD .placeholder ${PLUG_IN_PATHS} /output/plugins/
 COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
 RUN /usr/local/bin/geoserver-plugin-download.sh /output/plugins/ ${PLUG_IN_URLS}
 RUN \
-    if [ -f *.zip ] ; then \
+    if ls *.zip >/dev/null 2>&1; then \
        unzip -o "./*.zip"; \
+       rm ./*zip; \
     fi
 
 WORKDIR /output/webapp


### PR DESCRIPTION
Check for zip files using `ls` instead of `[ -f *zip ]`.
If `*` is expanded to more that one file, it becomes invalid syntax.