### PR TITLE
allow specifying third-party plugins via custom-build.sh, improve plugins download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM tomcat:9-jdk11-temurin-jammy as mother
 LABEL maintainer="Alessandro Parma <alessandro.parma@geosolutionsgroup.com>"
+LABEL org.opencontainers.image.version="${GEOSERVER_VERSION}"
+
 SHELL ["/bin/bash", "-c"]
 
 ARG CORS_ENABLED=false

--- a/custom_build.sh
+++ b/custom_build.sh
@@ -211,6 +211,7 @@ function build_without_data_dir() {
       ;;
   esac
     ${DOCKER_BUILD_COMMAND} --build-arg GEOSERVER_WEBAPP_SRC=${GEOSERVER_ARTIFACT_DIRECTORY}/geoserver.war \
+    --build-arg GEOSERVER_VERSION="${GEOSERVER_VERSION}" \
     --build-arg PLUG_IN_PATHS=$PLUGIN_ARTIFACT_DIRECTORY \
     --build-arg UID=${USERID} --build-arg GID=${GROUPID} --build-arg UNAME=${UNAME} \
     --build-arg GIT_HASH=${GIT_HASH_COMMAND} \

--- a/custom_build.sh
+++ b/custom_build.sh
@@ -170,6 +170,7 @@ function build_with_data_dir() {
   esac
     ${DOCKER_BUILD_COMMAND} --build-arg GEOSERVER_WEBAPP_SRC=${GEOSERVER_ARTIFACT_DIRECTORY}/geoserver.war \
     --build-arg PLUG_IN_PATHS=$PLUGIN_ARTIFACT_DIRECTORY \
+    --build-arg PLUG_IN_URLS="${PLUG_IN_URLS:-}" \
     --build-arg GEOSERVER_DATA_DIR_SRC=${DATADIR_ARTIFACT_DIRECTORY} \
     --build-arg UID=${USERID} --build-arg GID=${GROUPID} --build-arg UNAME=${UNAME} \
     --build-arg GIT_HASH=${GIT_HASH_COMMAND} \

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -12,7 +12,7 @@ do
     case "$url" in
         *sourceforge*) wget "$url/download" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
         ;;
-        *) wget -O ./download "$url" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH}
+        *) wget -O ./download "$url" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
         ;;
     esac
 done

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -14,7 +14,9 @@ do
         url="$url/download"
     fi
 
-    wget -O ./download "$url"
+    wget \
+        --no-verbose \
+        -O ./download "$url"
     unzip -o ./download -d "${PLUGIN_INSTALL_PATH}"
     rm ./download
 done

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -u
+
 [ "$#" -le "1" ] && ( echo "no plugin urls passed, exiting" ) && exit 0
 
 PLUGIN_INSTALL_PATH=$1

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -12,7 +12,7 @@ do
     case "$url" in
         *sourceforge*) wget "$url/download" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
         ;;
-        *) wget -O ./${url##*/} "$url" && unzip -o ./${url##*/} -d ${PLUGIN_INSTALL_PATH}
+        *) wget -O ./download "$url" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH}
         ;;
     esac
 done

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -9,10 +9,12 @@ PLUGIN_INSTALL_PATH=$1
 
 for url in "${@:2}"
 do
-    case "$url" in
-        *sourceforge*) wget "$url/download" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
-        ;;
-        *) wget -O ./download "$url" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
-        ;;
-    esac
+    # support specifying SourceForge URLs without the `/download` part at the end necessary for downloading
+    if [[ "$url" == *sourceforge* ]]; then
+        url="$url/download"
+    fi
+
+    wget -O ./download "$url"
+    unzip -o ./download -d ${PLUGIN_INSTALL_PATH}
+    rm ./download
 done

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -16,6 +16,7 @@ do
 
     wget \
         --no-verbose \
+        -U 'geosolutionsit/geoserver Docker image build' \
         -O ./download "$url"
     unzip -o ./download -d "${PLUGIN_INSTALL_PATH}"
     rm ./download

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -15,6 +15,6 @@ do
     fi
 
     wget -O ./download "$url"
-    unzip -o ./download -d ${PLUGIN_INSTALL_PATH}
+    unzip -o ./download -d "${PLUGIN_INSTALL_PATH}"
     rm ./download
 done

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -7,7 +7,7 @@ set -u
 
 PLUGIN_INSTALL_PATH=$1
 
-for url in "$@"
+for url in "${@:2}"
 do
     case "$url" in
         *sourceforge*) wget "$url/download" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download


### PR DESCRIPTION
Aside from fixing various bugs in `geoserver-plugin-download.sh`, the change in `custom-build.sh` allows me to build a Docker image with third-party (e.g. locally hosted) plugins.

There are some commits with a low but non-negligible changes of breaking users' workflows, those are marked with `<type>!` in the beginning following the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/#summary).

Also, I changed the Dockefile to expose the GeoServer version as a [`org.opencontainers.image.version` label](https://github.com/opencontainers/image-spec/blob/v1.1.0/annotations.md#pre-defined-annotation-keys) on the image.