### PR TITLE
entrypoint.sh: fix plugins extract path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-geoserver-plugin-download.sh ${CATALINA_BASE}/webapps/${APP_LOCATION}/WEB-INF/lib $PLUGIN_DYNAMIC_URLS
+geoserver-plugin-download.sh ${CATALINA_BASE}/webapps/geoserver/WEB-INF/lib $PLUGIN_DYNAMIC_URLS
 set -m
 export CATALINA_OPTS="$CATALINA_OPTS $EXTRA_GEOSERVER_OPTS"
 


### PR DESCRIPTION
https://github.com/geosolutions-it/docker-geoserver/blob/edb2b50df6437ead91ac8901e3bf0d88be4148e0/entrypoint.sh#L2

Consider the case where `APP_LOCATION` is not `geoserver`.
Here `${CATALINA_BASE}/webapps/${APP_LOCATION}` doesn't exist yet. It's still `${CATALINA_BASE}/webapps/geoserver`.
In case of a custom APP_LOCATION, the plugins install will fail.