### PR TITLE
feat: add psi probe with ability to enable during run/build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-temurin-jammy as mother
+FROM tomcat:10-jdk17-temurin-jammy as mother
 LABEL maintainer="Alessandro Parma <alessandro.parma@geosolutionsgroup.com>"
 SHELL ["/bin/bash", "-c"]
 
@@ -10,7 +10,7 @@ ARG CORS_ALLOW_CREDENTIALS=false
 
 # PSI Probe configuration
 ARG PSI_PROBE_ENABLED=false
-ARG PSI_PROBE_VERSION=3.5.1
+ARG PSI_PROBE_VERSION=5.3.0
 
 ENV CORS_ENABLED=$CORS_ENABLED
 ENV CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
@@ -93,7 +93,7 @@ RUN \
         touch .placeholder; \
     fi
 
-FROM tomcat:9-jdk11-temurin-jammy
+FROM tomcat:10-jdk17-temurin-jammy
 
 ARG UID=1000
 ARG GID=1000
@@ -179,6 +179,7 @@ COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
 COPY geoserver-rest-config.sh /usr/local/bin/geoserver-rest-config.sh
 COPY geoserver-rest-reload.sh /usr/local/bin/geoserver-rest-reload.sh
 COPY entrypoint.sh /entrypoint.sh
+COPY probe-src /tmp/probe-src
 COPY ${CUSTOM_FONTS} $GEOSERVER_DATA_DIR/styles/
 RUN groupadd -g $GID $UNAME
 RUN useradd -m -u $UID -g $GID --system $UNAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,20 @@ ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
 ARG CORS_ALLOWED_HEADERS=Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers
 ARG CORS_ALLOW_CREDENTIALS=false
 
+# PSI Probe configuration
+ARG PSI_PROBE_ENABLED=false
+ARG PSI_PROBE_VERSION=3.5.1
+
 ENV CORS_ENABLED=$CORS_ENABLED
 ENV CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
 ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
 ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
 ENV CORS_ALLOW_CREDENTIALS=$CORS_ALLOW_CREDENTIALS
+ENV PSI_PROBE_ENABLED=$PSI_PROBE_ENABLED
 
 ARG APP_LOCATION="geoserver"
 
-RUN apt-get update && apt-get install -y unzip
+RUN apt-get update && apt-get install -y unzip curl
 
 # accepts local files and URLs. Tar(s) are automatically extracted
 WORKDIR /output/datadir
@@ -60,6 +65,34 @@ RUN \
       mv /output/webapp/geoserver /output/webapp/${APP_LOCATION}; \
     fi
 
+# Download and prepare PSI Probe if enabled
+WORKDIR /output/probe
+RUN \
+    echo "PSI_PROBE_ENABLED=${PSI_PROBE_ENABLED}"; \
+    if [ "${PSI_PROBE_ENABLED}" = "true" ]; then \
+        echo "Downloading PSI Probe ${PSI_PROBE_VERSION}..."; \
+        # Try GitHub releases first
+        GITHUB_URL="https://github.com/psi-probe/psi-probe/releases/download/psi-probe-${PSI_PROBE_VERSION}/probe.war"; \
+        echo "Trying GitHub URL: ${GITHUB_URL}"; \
+        if curl -fSL "${GITHUB_URL}" -o probe.war; then \
+            echo "PSI Probe downloaded from GitHub ($(ls -lh probe.war))"; \
+        else \
+            echo "GitHub download failed, trying Maven Central..."; \
+            # Fallback to Maven Central
+            MAVEN_URL="https://repo1.maven.org/maven2/com/github/psi-probe/psi-probe-web/${PSI_PROBE_VERSION}/psi-probe-web-${PSI_PROBE_VERSION}.war"; \
+            echo "Trying Maven URL: ${MAVEN_URL}"; \
+            if curl -fSL "${MAVEN_URL}" -o probe.war; then \
+                echo "PSI Probe downloaded from Maven Central ($(ls -lh probe.war))"; \
+            else \
+                echo "ERROR: PSI Probe download failed from both sources!"; \
+                exit 1; \
+            fi; \
+        fi; \
+    else \
+        echo "PSI Probe disabled, skipping download"; \
+        touch .placeholder; \
+    fi
+
 FROM tomcat:9-jdk11-temurin-jammy
 
 ARG UID=1000
@@ -68,6 +101,10 @@ ARG UNAME=tomcat
 ARG CUSTOM_FONTS="./.placeholder"
 ENV ADMIN_PASSWORD=""
 ENV APP_LOCATION="geoserver"
+
+# PSI Probe configuration
+ENV PSI_PROBE_ENABLED="false"
+ENV PSI_PROBE_PASSWORD=""
 
 ENV CATALINA_BASE "$CATALINA_HOME"
 # set externalizations
@@ -134,6 +171,9 @@ RUN apt-get update \
 COPY --from=mother "/output/datadir" "${GEOSERVER_DATA_DIR}"
 COPY --from=mother "/output/webapp/geoserver" "${CATALINA_BASE}/webapps/geoserver"
 COPY --from=mother "/output/plugins" "${CATALINA_BASE}/webapps/geoserver/WEB-INF/lib"
+
+# copy PSI Probe if enabled
+COPY --from=mother "/output/probe" "/tmp/probe"
 
 COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
 COPY geoserver-rest-config.sh /usr/local/bin/geoserver-rest-config.sh

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ PSI Probe can be enabled at both build time and runtime with the following confi
 
 **Build-time arguments:**
 - `PSI_PROBE_ENABLED` - Enable/disable PSI Probe (default: `false`)
-- `PSI_PROBE_VERSION` - PSI Probe version to download (default: `3.5.1`)
+- `PSI_PROBE_VERSION` - PSI Probe version to download
 
 **Runtime environment variables:**
 - `PSI_PROBE_ENABLED` - Enable/disable PSI Probe at runtime (default: `false`)
@@ -134,7 +134,7 @@ services:
       args:
                  GEOSERVER_WEBAPP_SRC: "https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip"
          PSI_PROBE_ENABLED: "true"
-         PSI_PROBE_VERSION: "3.5.5"
+         PSI_PROBE_VERSION: "5.3.0"
     environment:
       PSI_PROBE_ENABLED: "true"
       PSI_PROBE_PASSWORD: "your-secure-password"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,68 @@ CORS headers can be configured with env variables (they are also build arguments
 - `CORS_ALLOW_CREDENTIALS` (default `false`) Setting this to true will only have the desired effect if 
 - `CORS_ALLOWED_ORIGINS` defines explicit origins (not *)
 
+### PSI Probe Integration
+
+This Docker image includes optional PSI Probe integration for monitoring database connections and connection pools. PSI Probe is a powerful web application monitoring tool that provides detailed insights into Tomcat's internals, including:
+
+- Database connection pool monitoring
+- Session tracking
+- Thread pool monitoring
+- Memory usage analysis
+- Application performance metrics
+
+#### PSI Probe Configuration
+
+PSI Probe can be enabled at both build time and runtime with the following configuration options:
+
+**Build-time arguments:**
+- `PSI_PROBE_ENABLED` - Enable/disable PSI Probe (default: `false`)
+- `PSI_PROBE_VERSION` - PSI Probe version to download (default: `3.5.1`)
+
+**Runtime environment variables:**
+- `PSI_PROBE_ENABLED` - Enable/disable PSI Probe at runtime (default: `false`)
+- `PSI_PROBE_PASSWORD` - Password for PSI Probe authentication (required for security)
+
+#### Usage Examples
+
+**Enable PSI Probe with Docker Compose:**
+
+```yaml
+services:
+  geoserver:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+                 GEOSERVER_WEBAPP_SRC: "https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip"
+         PSI_PROBE_ENABLED: "true"
+         PSI_PROBE_VERSION: "3.5.5"
+    environment:
+      PSI_PROBE_ENABLED: "true"
+      PSI_PROBE_PASSWORD: "your-secure-password"
+    ports:
+      - 8080:8080
+```
+
+**Enable PSI Probe with Docker run:**
+
+```bash
+docker run -e PSI_PROBE_ENABLED=true \
+           -e PSI_PROBE_PASSWORD=mypassword \
+           -p 8080:8080 \
+           geosolutionsit/geoserver
+```
+
+#### Accessing PSI Probe
+
+Once enabled, PSI Probe will be available at:
+- **Local access**: `http://localhost:8080/probe`
+- **Container access**: `http://container-ip:8080/probe`
+
+**Default credentials:**
+- **Username**: `probe`
+- **Password**: The value set in `PSI_PROBE_PASSWORD`
+
 ### Building with WAR files and plugins
 
 Example of how to build a docker image with just geoserver war and then add plugins at runtime.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       args:
         GEOSERVER_WEBAPP_SRC: "https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip"
         PSI_PROBE_ENABLED: "true"
-        PSI_PROBE_VERSION: "3.5.1"
+        PSI_PROBE_VERSION: "5.3.0"
     container_name: geoserver
     depends_on:
       postgres:
@@ -37,8 +37,8 @@ services:
     ports:
       - 8080
     environment:
-      PSI_PROBE_ENABLED: "true"
-      PSI_PROBE_PASSWORD: "geoserver"
+      PSI_PROBE_ENABLED: "false"
+      PSI_PROBE_PASSWORD: ""
     networks:
       - geoserver-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,17 @@ services:
       dockerfile: ./Dockerfile
       args:
         GEOSERVER_WEBAPP_SRC: "https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip"
+        PSI_PROBE_ENABLED: "true"
+        PSI_PROBE_VERSION: "3.5.1"
     container_name: geoserver
     depends_on:
       postgres:
         condition: service_healthy
     ports:
       - 8080
+    environment:
+      PSI_PROBE_ENABLED: "true"
+      PSI_PROBE_PASSWORD: "geoserver"
     networks:
       - geoserver-network
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -171,6 +171,80 @@ case "$GS_CORE_JAR" in
   ;;
 esac
 
+# Configure PSI Probe if enabled
+setup_psi_probe() {
+  if [ "${PSI_PROBE_ENABLED}" = "true" ]; then
+    printf "INFO: Setting up PSI Probe...\n"
+    
+    if [ -f "/tmp/probe/probe.war" ]; then
+      cp "/tmp/probe/probe.war" "$CATALINA_HOME/webapps/"
+      printf "INFO: PSI Probe WAR deployed\n"
+    else
+      printf "WARNING: PSI Probe WAR not found, skipping deployment\n"
+      return
+    fi
+    
+    if [ -n "${PSI_PROBE_PASSWORD}" ]; then
+      printf "INFO: Configuring PSI Probe security...\n"
+      
+      TOMCAT_USERS_XML="$CATALINA_HOME/conf/tomcat-users.xml"
+      
+      if [ ! -f "${TOMCAT_USERS_XML}.backup" ]; then
+        cp "$TOMCAT_USERS_XML" "${TOMCAT_USERS_XML}.backup"
+      fi
+      
+      cat > "$TOMCAT_USERS_XML" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+  <role rolename="manager-gui"/>
+  <role rolename="manager-script"/>
+  <role rolename="manager-status"/>
+  <role rolename="poweruser"/>
+  <role rolename="poweruserplus"/>
+  <role rolename="probeuser"/>
+  <user username="probe" password="${PSI_PROBE_PASSWORD}" roles="manager-gui,manager-script,manager-status,poweruser,poweruserplus,probeuser"/>
+</tomcat-users>
+EOF
+      
+      printf "INFO: PSI Probe user configured with provided password\n"
+    else
+      printf "WARNING: PSI_PROBE_PASSWORD not set, PSI Probe will be accessible without authentication\n"
+    fi
+    
+    # Force proper WAR extraction (fix Tomcat auto-deployment issues)
+    if [ -f "$CATALINA_HOME/webapps/probe.war" ]; then
+      printf "INFO: Ensuring PSI Probe WAR is properly extracted...\n"
+      cd "$CATALINA_HOME/webapps"
+      rm -rf probe
+      unzip -q probe.war -d probe
+      printf "INFO: PSI Probe WAR manually extracted\n"
+    fi
+    
+    # Configure access restrictions
+    printf "INFO: Configuring PSI Probe for Docker-compatible local access...\n"
+    CONTEXT_XML="$CATALINA_HOME/webapps/probe/META-INF/context.xml"
+    mkdir -p "$CATALINA_HOME/webapps/probe/META-INF"
+    cat > "$CONTEXT_XML" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<Context privileged="true">
+  <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+         allow="127\.0\.0\.1|::1|0:0:0:0:0:0:0:1|172\.1[6-9]\..*|172\.2[0-9]\..*|172\.3[0-1]\..*|10\..*|192\.168\..*"/>
+</Context>
+EOF
+    
+    printf "INFO: PSI Probe configured for Docker-compatible access\n"
+    
+    printf "INFO: PSI Probe setup completed\n"
+  else
+    printf "INFO: PSI Probe disabled, skipping setup\n"
+  fi
+}
+
+setup_psi_probe
+
 catalina.sh run &
 /usr/local/bin/geoserver-rest-config.sh
 fg %1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -186,32 +186,30 @@ setup_psi_probe() {
     
     if [ -n "${PSI_PROBE_PASSWORD}" ]; then
       printf "INFO: Configuring PSI Probe security...\n"
-      
+
       TOMCAT_USERS_XML="$CATALINA_HOME/conf/tomcat-users.xml"
       
       if [ ! -f "${TOMCAT_USERS_XML}.backup" ]; then
         cp "$TOMCAT_USERS_XML" "${TOMCAT_USERS_XML}.backup"
       fi
-      
-      cat > "$TOMCAT_USERS_XML" << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<tomcat-users xmlns="http://tomcat.apache.org/xml"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
-              version="1.0">
-  <role rolename="manager-gui"/>
-  <role rolename="manager-script"/>
-  <role rolename="manager-status"/>
-  <role rolename="poweruser"/>
-  <role rolename="poweruserplus"/>
-  <role rolename="probeuser"/>
-  <user username="probe" password="${PSI_PROBE_PASSWORD}" roles="manager-gui,manager-script,manager-status,poweruser,poweruserplus,probeuser"/>
-</tomcat-users>
-EOF
-      
+
+      if ! grep -q 'rolename="probeuser"' "$TOMCAT_USERS_XML"; then
+        printf "INFO: Patching tomcat-users.xml for PSI Probe\n"
+        sed -i "\:</tomcat-users>:i\\
+            <role rolename=\"probeuser\" />\n\
+            <role rolename=\"poweruser\" />\n\
+            <role rolename=\"poweruserplus\" />\n\
+            <role rolename=\"manager-gui\" />\n\
+          \n\
+            <user username=\"probe\" password=\"${PSI_PROBE_PASSWORD}\" roles=\"manager-gui\" />\n\
+          " "$TOMCAT_USERS_XML"
+      else
+        printf "INFO: tomcat-users.xml already has probeuser role, skipping\n"
+      fi
+
       printf "INFO: PSI Probe user configured with provided password\n"
     else
-      printf "WARNING: PSI_PROBE_PASSWORD not set, PSI Probe will be accessible without authentication\n"
+      printf "INFO: PSI_PROBE_PASSWORD not set, configuring PSI Probe for anonymous access\n"
     fi
     
     # Force proper WAR extraction (fix Tomcat auto-deployment issues)
@@ -230,13 +228,43 @@ EOF
     cat > "$CONTEXT_XML" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <Context privileged="true">
-  <Valve className="org.apache.catalina.valves.RemoteAddrValve"
-         allow="127\.0\.0\.1|::1|0:0:0:0:0:0:0:1|172\.1[6-9]\..*|172\.2[0-9]\..*|172\.3[0-1]\..*|10\..*|192\.168\..*"/>
 </Context>
 EOF
-    
-    printf "INFO: PSI Probe configured for Docker-compatible access\n"
-    
+
+    PROBE_WEB_XML="$CATALINA_HOME/webapps/probe/WEB-INF/web.xml"
+
+    # When no password is set, replace ProbeSecurityConfig with no-auth version
+    # and strip web.xml security constraints to allow anonymous access
+    if [ -z "${PSI_PROBE_PASSWORD}" ] && [ -f "$PROBE_WEB_XML" ]; then
+      if [ -f "/tmp/probe-src/ProbeSecurityConfig.java" ]; then
+        printf "INFO: Compiling no-auth ProbeSecurityConfig...\n"
+        mkdir -p "$CATALINA_HOME/webapps/probe/WEB-INF/classes"
+        javac -cp "$CATALINA_HOME/webapps/probe/WEB-INF/lib/*:$CATALINA_HOME/lib/*" \
+          -d "$CATALINA_HOME/webapps/probe/WEB-INF/classes" \
+          /tmp/probe-src/ProbeSecurityConfig.java
+        printf "INFO: Replaced ProbeSecurityConfig with no-auth version\n"
+      else
+        printf "WARNING: No-auth ProbeSecurityConfig.java not found at /tmp/probe-src/, probe may require auth\n"
+      fi
+
+      # Strip security-constraint and login-config from web.xml
+      TEMP_PROBE_WEB_XML=$(mktemp)
+      awk '
+        /<security-constraint>/ { in_security_constraint=1; next }
+        /<\/security-constraint>/ { in_security_constraint=0; next }
+        /<login-config>/ { in_login_config=1; next }
+        /<\/login-config>/ { in_login_config=0; next }
+        !in_security_constraint && !in_login_config { print }
+      ' "$PROBE_WEB_XML" > "$TEMP_PROBE_WEB_XML" && mv "$TEMP_PROBE_WEB_XML" "$PROBE_WEB_XML"
+      printf "INFO: PSI Probe security constraints removed for anonymous access\n"
+    fi
+
+    # Disable HTTPS redirect - allow plain HTTP access
+    if [ -f "$PROBE_WEB_XML" ] && grep -q "CONFIDENTIAL" "$PROBE_WEB_XML" 2>/dev/null; then
+      sed -i 's|<transport-guarantee>CONFIDENTIAL</transport-guarantee>|<transport-guarantee>NONE</transport-guarantee>|g' "$PROBE_WEB_XML"
+      printf "INFO: PSI Probe HTTPS redirect disabled\n"
+    fi
+
     printf "INFO: PSI Probe setup completed\n"
   else
     printf "INFO: PSI Probe disabled, skipping setup\n"

--- a/geoserver.conf
+++ b/geoserver.conf
@@ -40,10 +40,13 @@ server {
         proxy_max_temp_file_size 2048m;
         proxy_temp_file_write_size 512k;
 
-        location / {
-                deny all;
-                return 301 /geoserver;
-        }
+    location /probe {
+        proxy_pass  http://geoserver:8080/probe;
+    }
+
+    location / {
+        return 301 /geoserver;
+    }
 
     location /geoserver {
         proxy_pass         http://geoserver:8080/geoserver;

--- a/probe-src/ProbeSecurityConfig.java
+++ b/probe-src/ProbeSecurityConfig.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the GPL License. You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+ * WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE.
+ */
+package psiprobe;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.NullPermission;
+import com.thoughtworks.xstream.security.PrimitiveTypePermission;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.TreeMap;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * No-auth version of ProbeSecurityConfig.
+ *
+ * <p>This replaces the original security config to allow open access when no password is set.
+ * All J2EE pre-authentication, role-based access control, and FilterSecurityInterceptor
+ * are removed. A passthrough filter is used instead, allowing all requests through.</p>
+ */
+@Configuration
+@EnableWebSecurity
+public class ProbeSecurityConfig {
+
+  /**
+   * Gets the filter chain proxy.
+   * Uses a passthrough filter instead of FilterSecurityInterceptor.
+   *
+   * @return the filter chain proxy
+   */
+  @Bean(name = "filterChainProxy")
+  public FilterChainProxy getFilterChainProxy() {
+    SecurityFilterChain chain = new DefaultSecurityFilterChain(new AntPathRequestMatcher("/**"),
+        securityContextHolderFilter(securityContextRepository()),
+        getLogoutFilter(),
+        new GenericFilterBean() {
+          @Override
+          public void doFilter(ServletRequest request, ServletResponse response,
+              FilterChain filterChain) throws IOException, ServletException {
+            filterChain.doFilter(request, response);
+          }
+        });
+    return new FilterChainProxy(chain);
+  }
+
+  /**
+   * Security context holder filter.
+   *
+   * @param repository the repository
+   * @return the security context holder filter
+   */
+  @Bean
+  public SecurityContextHolderFilter securityContextHolderFilter(
+      SecurityContextRepository repository) {
+    return new SecurityContextHolderFilter(repository);
+  }
+
+  /**
+   * Security context repository.
+   *
+   * @return the security context repository
+   */
+  @Bean
+  public SecurityContextRepository securityContextRepository() {
+    return new HttpSessionSecurityContextRepository();
+  }
+
+  /**
+   * Gets the logout filter.
+   *
+   * @return the logout filter
+   */
+  @Bean(name = "logoutFilter")
+  public LogoutFilter getLogoutFilter() {
+    return new LogoutFilter("/", getSecurityContextLogoutHandler());
+  }
+
+  /**
+   * Gets the security context logout handler.
+   *
+   * @return the security context logout handler
+   */
+  @Bean(name = "securityContextLogoutHandler")
+  public SecurityContextLogoutHandler getSecurityContextLogoutHandler() {
+    return new SecurityContextLogoutHandler();
+  }
+
+  /**
+   * Gets the security context holder aware request filter.
+   *
+   * @return the security context holder aware request filter
+   */
+  @Bean(name = "securityContextHolderAwareRequestFilter")
+  public SecurityContextHolderAwareRequestFilter getSecurityContextHolderAwareRequestFilter() {
+    return new SecurityContextHolderAwareRequestFilter();
+  }
+
+  /**
+   * Gets the http session request cache.
+   *
+   * @return the http session request cache
+   */
+  @Bean(name = "httpSessionRequestCache")
+  public HttpSessionRequestCache getHttpSessionRequestCache() {
+    HttpSessionRequestCache cache = new HttpSessionRequestCache();
+    cache.setCreateSessionAllowed(false);
+    return cache;
+  }
+
+  /**
+   * Gets the xstream.
+   *
+   * @return the xstream
+   */
+  @Bean(name = "xstream")
+  public XStream getXstream() {
+    XStream xstream = new XStream();
+    // clear out existing permissions and start a whitelist
+    xstream.addPermission(NoTypePermission.NONE);
+    // allow some basics
+    xstream.addPermission(NullPermission.NULL);
+    xstream.addPermission(PrimitiveTypePermission.PRIMITIVES);
+    xstream.allowTypeHierarchy(Collection.class);
+    xstream.allowTypeHierarchy(String.class);
+    xstream.allowTypeHierarchy(TreeMap.class);
+    xstream.allowTypesByWildcard(new String[] {"org.jfree.data.xy.**", "psiprobe.controllers.**",
+        "psiprobe.model.**", "psiprobe.model.stats.**"});
+    return xstream;
+  }
+
+}


### PR DESCRIPTION
This PR adds the support for PSI Probe, with the ability to disable/enable during build/run time. And with the access control for only: localhost (IPv4 and IPv6), and some common private network ranges (e.g: Docker bridges network) to access the PSI Probe. [Original issue](https://github.com/geosolutions-it/DevOps/issues/1621)

**Changes introduced:**

- [X] Update `Dockerfile` to add the download and installation PSI Probe
- [X] Update `entrypoint.sh` with the access control to just allow access from localhost/private network ranges
- [X] Update `docker-compose.yml` with the ability to enable/disable the probe

