### PR TITLE
Remove the echo while waiting for GS to be healthy

### DIFF
--- a/geoserver-rest-config.sh
+++ b/geoserver-rest-config.sh
@@ -5,7 +5,7 @@ if [ -z "${APP_LOCATION}" ]; then
 fi
 
 while [ "$(curl -s --retry-connrefused --retry 100 -I http://localhost:8080/"$APP_LOCATION"/web/ 2>&1 |grep 200)" == "" ];do
-    echo "Waiting for GeoServer to be Up and running"
+    :
 done
 if [ "$ADMIN_PASSWORD" != "" ]; then
     echo "GeoServer password is likely to be default, going to change to new admin password."


### PR DESCRIPTION
This is primarily to avoid spamming the logs when geoserver crashes for whatever reason.