### PR TITLE
fix: support Docker 2x versions in buildx condition in gs-main

### DIFF
--- a/custom_build.sh
+++ b/custom_build.sh
@@ -186,7 +186,7 @@ function build_without_data_dir() {
 	local PULL_ENABLED=${2}
   DOCKER_VERSION="$(docker --version | grep "Docker version"| awk '{print $3}' | sed 's/,//')"
   case $DOCKER_VERSION in
-    *"20"*)
+    2[0-9].*)
       docker builder prune --all -f
       if [[ "${PULL_ENABLED}" == "pull" ]]; then
         DOCKER_BUILD_COMMAND="docker buildx build --pull"

--- a/custom_build.sh
+++ b/custom_build.sh
@@ -149,7 +149,7 @@ function build_with_data_dir() {
   local PULL_ENABLED=${2}
   DOCKER_VERSION="$(docker --version | grep "Docker version"| awk '{print $3}' | sed 's/,//')"
   case $DOCKER_VERSION in
-    *"20"*)
+    2[0-9].*)
       if [[ "${PULL_ENABLED}" == "pull" ]]; then
         DOCKER_BUILD_COMMAND="docker buildx build --pull"
       else


### PR DESCRIPTION
This PR updates the buildx condition to support Docker 20.x-29.x versions

**Changed Introduce**
- `custom_build.sh`: Updated the buildx condition