### PR TITLE
fix: fail image builds when plugin downloads or extraction fail & added code readability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ RUN /usr/local/bin/geoserver-plugin-download.sh /output/plugins/ ${PLUG_IN_URLS}
 RUN \
     # We want ZIPs  to be extracted in alphabetical order, so we don't use `unzip -o "./*.zip"`. \
     # Useful when applying patches.
-    find . -type f -name '*.zip' | sort | xargs -I {} unzip -o {}; \
+    set -euo pipefail; \
+    find . -type f -name '*.zip' -print0 | sort -z | xargs -0 -r -n 1 unzip -o; \
     rm -f ./*.zip
 
 WORKDIR /output/webapp

--- a/geoserver-plugin-download.sh
+++ b/geoserver-plugin-download.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
 
-[ "$#" -le "1" ] && ( echo "no plugin urls passed, exiting" ) && exit 0
+set -euo pipefail
+
+if [ "$#" -le 1 ]; then
+    echo "no plugin urls passed, exiting"
+    exit 0
+fi
 
 PLUGIN_INSTALL_PATH=$1
+shift
 
-for url in "$@"
-do
+for url in "$@"; do
     case "$url" in
-        *sourceforge*) wget "$url/download" && unzip -o ./download -d ${PLUGIN_INSTALL_PATH} && rm ./download
+        *sourceforge*)
+            wget -O ./download "$url/download"
+            unzip -o ./download -d "$PLUGIN_INSTALL_PATH"
+            rm -f ./download
         ;;
-        *) wget -O ./${url##*/} "$url" && unzip -o ./${url##*/} -d ${PLUGIN_INSTALL_PATH}
+        *)
+            archive_name=${url##*/}
+            wget -O "./$archive_name" "$url"
+            unzip -o "./$archive_name" -d "$PLUGIN_INSTALL_PATH"
         ;;
     esac
 done


### PR DESCRIPTION
## Old Behaviour
When `PLUG_IN_URLS` passed as argument with broken URL's to docker build, if the url doesn't return plugin file or 404's the build doesn't fail and hence ends up with missing plugins in final image. Also, `PLUGIN_INSTALL_PATH` ie: `/output/plugins/` is treated as a url thus producing `#20 0.128 ./: Is a directory`

## Updates

- `set -euo pipefail` to `geoserver-plugin-download.sh`, failure in download should fail the build.
- Added `shift`, so  `wget` doesn't treat `PLUGIN_INSTALL_PATH`  as a url.
- handle unusual filenames, before unzip eg: file with spaces `./plugins/my custom plugin.zip`
- Readability and format


## Validation
`https://build.geoserver.org/geoserver/2.28.x/community-404/geoserver-2.28-SNAPSHOT-wps-longitudinal-profile-plugin.zip`
is the failing plugins url.

```
docker build --no-cache --progress=plain \
  -t geoserver-404-test:should-fail \
  --build-arg GEOSERVER_WEBAPP_SRC='https://build.geoserver.org/geoserver/2.28.x/geoserver-2.28.x-latest-war.zip' \
  --build-arg PLUG_IN_URLS='https://build.geoserver.org/geoserver/2.28.x/community-404/geoserver-2.28-SNAPSHOT-wps-longitudinal-profile-plugin.zip https://build.geoserver.org/geoserver/2.28.x/ext-latest/geoserver-2.28-SNAPSHOT-control-flow-plugin.zip' \
  .
```
fails with `404 Not Found`, an thus exit code: 8 from `wget` which is expected.
```
------
 > [mother 12/15] RUN /usr/local/bin/geoserver-plugin-download.sh /output/plugins/ https://build.geoserver.org/geoserver/2.28.x/community-404/geoserver-2.28-SNAPSHOT-wps-longitudinal-profile-plugin.zip https://build.geoserver.org/geoserver/2.28.x/ext-latest/geoserver-2.28-SNAPSHOT-control-flow-plugin.zip:
connected.
404 Not Found
1.481 2026-09-01 10:02:44 ERROR 404: Not Found.
1.481
--------------------
  48 |     ADD .placeholder ${PLUG_IN_PATHS} /output/plugins/
  49 |     COPY geoserver-plugin-download.sh /usr/local/bin/geoserver-plugin-download.sh
  50 | >>> RUN /usr/local/bin/geoserver-plugin-download.sh /output/plugins/ ${PLUG_IN_URLS}
  51 |     RUN \
  52 |         # We want ZIPs  to be extracted in alphabetical order, so we don't use `unzip -o "./*.zip"`. \
--------------------
ERROR: failed to build: failed to solve: process "/bin/bash -c /usr/local/bin/geoserver-plugin-download.sh /output/plugins/ ${PLUG_IN_URLS}" did not complete successfully: exit code: 8
```