### PR TITLE
Bump base image from jdk11 to jdk21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9-jdk11-temurin-jammy as mother
+FROM tomcat:9-jdk21-temurin-jammy as mother
 LABEL maintainer="Alessandro Parma <alessandro.parma@geosolutionsgroup.com>"
 SHELL ["/bin/bash", "-c"]
 
@@ -60,7 +60,7 @@ RUN \
       mv /output/webapp/geoserver /output/webapp/${APP_LOCATION}; \
     fi
 
-FROM tomcat:9-jdk11-temurin-jammy
+FROM tomcat:9-jdk21-temurin-jammy
 
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
JDK 11 is too old for the latest GeoServer versions.